### PR TITLE
moved asset depenencies to separate file

### DIFF
--- a/composer.assets.json
+++ b/composer.assets.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+         "bower-asset/bootstrap": "^4.1.0"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,7 @@
         }
     ],
     "require": {
-        "yiisoft/yii-core": "^3.0@dev",
-        "bower-asset/bootstrap": "^4.1.0"
+        "yiisoft/yii-core": "^3.0@dev"
     },
     "require-dev": {
         "yiisoft/di": "^3.0@dev",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "license": "BSD-3-Clause",
+  "dependencies": {
+    "bootstrap": "^4.1.3",
+    "jquery": "^3.3.1",
+    "popper.js": "^1.14.5"
+  }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | yes
| Tests pass?   | ?

Composer (asset-packagist (AP)) currently points to bower, I think we should change that also.

When now working either with `npm-asset/...` or native npm, we should think about using a common `$sourcePath` for asset bundles or find some other way to handle that. I am not sure if you can change the paths used by AP or if the user should be advised to change `node_modules` to `vendor/npm-asset`.