### PR TITLE
Update Button.php to use glyphicons

### DIFF
--- a/src/Button.php
+++ b/src/Button.php
@@ -12,6 +12,7 @@ namespace Yiisoft\Yii\Bootstrap4;
  * ```php
  * echo Button::widget()
  *     ->label('Action')
+ *     ->icon('play-circle')
  *     ->options(['class' => 'btn-lg']);
  * ```
  */
@@ -20,6 +21,8 @@ class Button extends Widget
     private string $tagName = 'button';
 
     private string $label = 'Button';
+    
+    private string $icon = false;
 
     private bool $encodeLabels = true;
 
@@ -34,7 +37,11 @@ class Button extends Widget
         Html::addCssClass($this->options, ['widget' => 'btn']);
 
         $this->registerPlugin('button', $this->options);
-
+        if(false !== $this->icon){
+            $this->encodeLabels = true;
+            $this->label = '<span class="glyphicon glyphicon-'.$this->icon.'"></span>'.$this->label;
+        }
+        
         return Html::tag(
             $this->tagName,
             $this->encodeLabels ? Html::encode($this->label) : $this->label,
@@ -61,6 +68,18 @@ class Button extends Widget
 
         return $this;
     }
+    
+    /**
+     * The button icon (bootstrap icons allowed)
+     * @param bool||string $iconName if FALSE no icon will be rendered 
+     */
+    public function icon(string $iconName): self
+    {
+        $this->icon = $iconName;
+        
+        return $this;
+    }
+
 
     /**
      * The HTML attributes for the widget container tag. The following special options are recognized.

--- a/src/Button.php
+++ b/src/Button.php
@@ -37,14 +37,11 @@ class Button extends Widget
         Html::addCssClass($this->options, ['widget' => 'btn']);
 
         $this->registerPlugin('button', $this->options);
-        if(empty($this->icon)){
-            $this->encodeLabels = true;
-            $this->label = '<span class="glyphicon glyphicon-'.$this->icon.'"></span>'.$this->label;
-        }
-        
+                
         return Html::tag(
             $this->tagName,
-            $this->encodeLabels ? Html::encode($this->label) : $this->label,
+            empty($this->icon)  ? ($this->encodeLabels ? Html::encode($this->label) : $this->label)
+                                : ($this->encodeLabels ? '<span class="glyphicon glyphicon-'.$this->icon.'"></span>' . Html::encode($this->label) : '<span class="glyphicon glyphicon-'.$this->icon.'"></span>' . $this->label),
             $this->options
         );
     }

--- a/src/Button.php
+++ b/src/Button.php
@@ -22,7 +22,7 @@ class Button extends Widget
 
     private string $label = 'Button';
     
-    private string $icon = false;
+    private string $icon = '';
 
     private bool $encodeLabels = true;
 
@@ -37,7 +37,7 @@ class Button extends Widget
         Html::addCssClass($this->options, ['widget' => 'btn']);
 
         $this->registerPlugin('button', $this->options);
-        if(false !== $this->icon){
+        if(empty($this->icon)){
             $this->encodeLabels = true;
             $this->label = '<span class="glyphicon glyphicon-'.$this->icon.'"></span>'.$this->label;
         }
@@ -71,7 +71,7 @@ class Button extends Widget
     
     /**
      * The button icon (bootstrap icons allowed)
-     * @param bool||string $iconName if FALSE no icon will be rendered 
+     * @param string $iconName if empty no icon will be rendered 
      */
     public function icon(string $iconName): self
     {


### PR DESCRIPTION
Now you can choose an optional icon simply call the method Button::icon('$iconName').

EDIT: added a new empty line at 44.
2nd EDIT: fixed |== instead of !== at line 40 :(

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ❌